### PR TITLE
fix: Invalid IFC-File export due to missing apostrophy.

### DIFF
--- a/src/wasm/include/web-ifc.h
+++ b/src/wasm/include/web-ifc.h
@@ -776,7 +776,7 @@ namespace webifc
 
 			file << "ISO-10303-21;" << std::endl;
 			file << "HEADER;" << std::endl;
-			file << "FILE_DESCRIPTION(('" << description << "), '2;1');" << std::endl;
+			file << "FILE_DESCRIPTION(('" << description << "'), '2;1');" << std::endl;
 			file << "FILE_NAME('" << name << "', '', (''), (''), 'web-ifc-export');" << std::endl;
 			file << "FILE_SCHEMA(('IFC2X3'));" << std::endl;
 			file << "ENDSEC;" << std::endl;


### PR DESCRIPTION
A very simple bug. There's a missing `'` which causes the exported IFC File to be invalid.