### PR TITLE
Fixing first token detection in tokenizer.h

### DIFF
--- a/src/wasm/include/parsing/tokenizer.h
+++ b/src/wasm/include/parsing/tokenizer.h
@@ -52,7 +52,7 @@ namespace webifc
 		{
 			bool eof = false;
 			bool isSTEPLine = false;
-			bool firstToken = true;
+			
 			while (true)
 			{
 				if (pos >= len)
@@ -63,10 +63,11 @@ namespace webifc
 
 				const char c = buf[pos];
 
+				bool isFirstToken = pos == 0 || (buf[pos - 1] == '\n' && buf[pos - 2] == ';');
 				bool isWhiteSpace = c == ' ' || c == '\n' || c == '\r' || c == '\t';
 
 				// only consider a line a stepline if the very first non-whitespace character is a ref
-				if (!isWhiteSpace && firstToken && c == '#')
+				if (!isWhiteSpace && isFirstToken && c == '#')
 				{
 					isSTEPLine = true;
 				}


### PR DESCRIPTION
Fixing first token detection due to some IFC files having '#' characters in the header causing empty lines to be added to parser.