### PR TITLE
Fix large amount of content skipped when chunk ends with closing apostrophe

### DIFF
--- a/src/cpp/parsing/IfcFileStream.cpp
+++ b/src/cpp/parsing/IfcFileStream.cpp
@@ -48,7 +48,7 @@
         if (_startRef > 0) {
           _startRef--;
           load();
-          _pointer = _currentSize - 1;
+          _pointer = 0;
         }
       } 
       else


### PR DESCRIPTION
When a text was being tokenized and the closing apostrophe falled at the end of the current content chunk, content part (equal to the size of the buffer -1) had been skipped.