### PR TITLE
Export wasm files

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
       "node": "./web-ifc-api-node.js",
       "import": "./web-ifc-api.js",
       "browser": "./web-ifc-api.js"
-    }
+    },
+    "./web-ifc.wasm": "./web-ifc.wasm",
+    "./web-ifc-mt.wasm": "./web-ifc-mt.wasm",
+    "./web-ifc-node.wasm": "./web-ifc-node.wasm"
   },
   "pckg-gui": {},
   "scripts": {


### PR DESCRIPTION
Export wasm files in `package.json` so they can be imported in vite projects like this

```ts
import ifcWasmUrl from "web-ifc/web-ifc.wasm?url";
```