### PR TITLE
fix: document.currentScript is null exception

### DIFF
--- a/src/ts/web-ifc-api.ts
+++ b/src/ts/web-ifc-api.ts
@@ -29,7 +29,7 @@ let WebIFCWasm: any;
 let currentScriptPath: string;
 if (typeof document !== 'undefined') {
     const currentScriptData  = (document.currentScript as HTMLScriptElement);
-    if (typeof currentScriptData.src !== 'undefined') currentScriptPath = currentScriptData.src.substring(0, currentScriptData.src.lastIndexOf("/") + 1) ;
+    if (typeof currentScriptData?.src !== 'undefined') currentScriptPath = currentScriptData.src.substring(0, currentScriptData.src.lastIndexOf("/") + 1) ;
 }
 
 export * from "./ifc-schema";


### PR DESCRIPTION

using `currentScriptData?.src` rather than `currentScriptData.src` fixes following exception


![image](https://github.com/user-attachments/assets/b8d4acb3-3d77-4a6f-80bd-955ca16f794a)
