### PR TITLE
Add check in Extrude(), replace replace codecvt_utf8_utf16 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ examples/nodejs/*.ifc
 tests/ifcfiles/private/*.ifc
 tests/ifcfiles/private/*.stl
 tests/ifcfiles/created.ifc
+src/cpp/_deps/

--- a/src/cpp/web-ifc/geometry/nurbs.h
+++ b/src/cpp/web-ifc/geometry/nurbs.h
@@ -13,10 +13,10 @@ namespace tinynurbs{
 
 namespace webifc::geometry{
 
-	class IfcGeometry;
-	class IfcBound3D;
-	class BSpline;
-	class IfcSurface;
+	struct IfcGeometry;
+	struct IfcBound3D;
+	struct BSpline;
+	struct IfcSurface;
 
 	constexpr double rotations 		{ 6.0 };
   constexpr auto pi {glm::pi<double>()};

--- a/src/cpp/web-ifc/geometry/operations/geometryutils.h
+++ b/src/cpp/web-ifc/geometry/operations/geometryutils.h
@@ -152,7 +152,9 @@ namespace webifc::geometry
 						// this is bad news, as it nans the points added to the final mesh
 						// also, it's hard to bail out now :/
 						// see curve.add() for more info on how this is currently "solved"
+#if defined(_DEBUG)
 						printf("NaN perp!\n");
+#endif
 					}
 
 					glm::dvec3 u1 = glm::normalize(glm::cross(n1, p));
@@ -363,7 +365,9 @@ namespace webifc::geometry
 						// this is bad news, as it nans the points added to the final mesh
 						// also, it's hard to bail out now :/
 						// see curve.add() for more info on how this is currently "solved"
+#if defined(_DEBUG)
 						printf("NaN perp!\n");
+#endif
 					}
 
 					glm::dvec3 u1 = glm::normalize(glm::cross(n1, p));
@@ -931,19 +935,22 @@ namespace webifc::geometry
 		}
 
 		uint32_t capSize = profile.curve.points.size();
-		for (size_t i = 1; i < capSize; i++)
+		for (size_t i = 1; i <= capSize; i++)
 		{
 			// https://github.com/tomvandig/web-ifc/issues/5
-			if (holesIndicesHash[i])
+			if (i < capSize)
 			{
-				continue;
+				if (holesIndicesHash[i])
+				{
+					continue;
+				}
 			}
 
 			uint32_t bl = i - 1;
-			uint32_t br = i - 0;
+			uint32_t br = i % capSize;
 
 			uint32_t tl = capSize + i - 1;
-			uint32_t tr = capSize + i - 0;
+			uint32_t tr = capSize + i  % capSize;
 
 			// this winding should be correct
 			geom.AddFace(geom.GetPoint(tl),

--- a/src/cpp/web-ifc/geometry/operations/geometryutils.h
+++ b/src/cpp/web-ifc/geometry/operations/geometryutils.h
@@ -824,6 +824,12 @@ namespace webifc::geometry
 		IfcGeometry geom;
 		std::vector<bool> holesIndicesHash;
 
+		// check if first point is equal to last point, otherwise the outer loop of the shape is not closed
+		glm::dvec3 lastToFirstPoint = profile.curve.points.front() - profile.curve.points.back();
+		if (glm::length(lastToFirstPoint) > 1e-8) {
+			profile.curve.points.push_back(profile.curve.points.front());
+		}
+
 		// build the caps
 		{
 			using Point = std::array<double, 2>;
@@ -935,31 +941,28 @@ namespace webifc::geometry
 		}
 
 		uint32_t capSize = profile.curve.points.size();
-		for (size_t i = 1; i <= capSize; i++)
+		for (size_t i = 1; i < capSize; i++)
 		{
 			// https://github.com/tomvandig/web-ifc/issues/5
-			if (i < capSize)
+			if (holesIndicesHash[i])
 			{
-				if (holesIndicesHash[i])
-				{
-					continue;
-				}
+				continue;
 			}
 
 			uint32_t bl = i - 1;
-			uint32_t br = i % capSize;
+			uint32_t br = i - 0;
 
 			uint32_t tl = capSize + i - 1;
-			uint32_t tr = capSize + i  % capSize;
+			uint32_t tr = capSize + i - 0;
 
 			// this winding should be correct
 			geom.AddFace(geom.GetPoint(tl),
-						 geom.GetPoint(br),
-						 geom.GetPoint(bl));
+				geom.GetPoint(br),
+				geom.GetPoint(bl));
 
 			geom.AddFace(geom.GetPoint(tl),
-						 geom.GetPoint(tr),
-						 geom.GetPoint(br));
+				geom.GetPoint(tr),
+				geom.GetPoint(br));
 		}
 
 		return geom;

--- a/src/cpp/web-ifc/geometry/operations/geometryutils.h
+++ b/src/cpp/web-ifc/geometry/operations/geometryutils.h
@@ -957,12 +957,12 @@ namespace webifc::geometry
 
 			// this winding should be correct
 			geom.AddFace(geom.GetPoint(tl),
-				geom.GetPoint(br),
-				geom.GetPoint(bl));
+						geom.GetPoint(br),
+						geom.GetPoint(bl));
 
 			geom.AddFace(geom.GetPoint(tl),
-				geom.GetPoint(tr),
-				geom.GetPoint(br));
+						geom.GetPoint(tr),
+						geom.GetPoint(br));
 		}
 
 		return geom;


### PR DESCRIPTION
In Extrude(): check if first point is equal to last point, otherwise the outer loop of the shape is not closed
In string_parsing.cpp, replace codecvt_utf8_utf16  which is deprecated in C++17