### PR TITLE
IfcLoader::SaveFile: option to order the STEP lines

### DIFF
--- a/src/cpp/wasm/web-ifc-wasm.cpp
+++ b/src/cpp/wasm/web-ifc-wasm.cpp
@@ -53,7 +53,7 @@ void SaveModel(uint32_t modelID, emscripten::val callback)
     manager.GetIfcLoader(modelID)->SaveFile([&](char* src, size_t srcSize)
         {
             emscripten::val retVal = callback((uint32_t)src, srcSize);
-        }
+        }, false
     );
 }
 

--- a/src/cpp/web-ifc/parsing/IfcLoader.cpp
+++ b/src/cpp/web-ifc/parsing/IfcLoader.cpp
@@ -76,7 +76,7 @@ namespace webifc::parsing {
      ParseLines();
    }
    
-   void IfcLoader::SaveFile(const std::function<void(char *, size_t)> &outputData) const
+   void IfcLoader::SaveFile(const std::function<void(char *, size_t)> &outputData, bool orderLinesByExpressID) const
    { 
       std::ostringstream output;
       output << "ISO-10303-21;"<<std::endl<<"HEADER;"<<std::endl;
@@ -97,6 +97,10 @@ namespace webifc::parsing {
           currentLines =  new std::vector<IfcLine*>();
           std::transform( _lines.begin(), _lines.end(), std::back_inserter( *currentLines ), [](auto &kv){ return kv.second;}  );
         }
+		if (orderLinesByExpressID) {
+			// Sort based on tapeOffset, which preserves the order by which the lines have been pushed
+			std::sort(currentLines->begin(), currentLines->end(), [](const IfcLine* a, const IfcLine* b) { return a->tapeOffset < b->tapeOffset; });
+		}
         for(uint32_t i=0; i < currentLines->size();i++)
         {
        
@@ -206,13 +210,11 @@ namespace webifc::parsing {
       outputData((char*)tmp.c_str(),tmp.size());
    }
    
-   void IfcLoader::SaveFile(std::ostream &outputData) const
+   void IfcLoader::SaveFile(std::ostream &outputData, bool orderLinesByExpressID) const
    { 
-     SaveFile([&](char* src, size_t srcSize)
-      {
+     SaveFile([&](char* src, size_t srcSize) {
           outputData.write(src,srcSize);
-      }
-    );
+		 },orderLinesByExpressID);
    }
       
    bool IfcLoader::IsAtEnd() const

--- a/src/cpp/web-ifc/parsing/IfcLoader.h
+++ b/src/cpp/web-ifc/parsing/IfcLoader.h
@@ -25,8 +25,8 @@ namespace webifc::parsing
       const std::vector<uint32_t> GetHeaderLinesWithType(const uint32_t type) const;
       void LoadFile(const std::function<uint32_t(char *, size_t, size_t)> &requestData);
       void LoadFile(std::istream &requestData);
-      void SaveFile(const std::function<void(char *, size_t)> &outputData) const;
-      void SaveFile(std::ostream &outputData) const;
+      void SaveFile(const std::function<void(char *, size_t)> &outputData, bool orderLinesByExpressID) const;
+      void SaveFile(std::ostream &outputData, bool orderLinesByExpressID) const;
       const std::vector<uint32_t> GetExpressIDsWithType(const uint32_t type) const;
       uint32_t GetMaxExpressId() const;
       bool IsValidExpressID(const uint32_t expressID) const;


### PR DESCRIPTION
Without ordering, the lines are in a random order, which makes it hard to track issues in exported files