### PR TITLE
fix: unnecessary warning removed

### DIFF
--- a/src/ts/web-ifc-api.ts
+++ b/src/ts/web-ifc-api.ts
@@ -588,7 +588,6 @@ export class IfcAPI {
      */
     GetNameFromTypeCode(type:number): string 
     {
-       Log.warn("GetNameFromTypeCode() now returns type names in camel case");
        return this.wasmModule.GetNameFromTypeCode(type);
     }
 


### PR DESCRIPTION
@beachtom It seem's like you've added this warning a year ago. In my opinion it's not necessary. If you want to keep it pls change it to a info log level.

Why do I want to remove it? - If I call the `getSpatialStructure` function, this warning will be printed inside my console thousands of times. It's kind of annoying :)
