### PR TITLE
ensure proper deletion of buffers

### DIFF
--- a/src/cpp/web-ifc/geometry/representation/IfcGeometry.cpp
+++ b/src/cpp/web-ifc/geometry/representation/IfcGeometry.cpp
@@ -210,7 +210,7 @@ namespace webifc::geometry {
 		return  resultMat;
 	}
 
-	uint32_t IfcGeometry::GetVertexData()
+	uintptr_t IfcGeometry::GetVertexData()
 	{
 		// unfortunately webgl can't do doubles
 		if (fvertexData.size() != vertexData.size())
@@ -228,7 +228,7 @@ namespace webifc::geometry {
 		{
 			return 0;
 		}
-		return (uint32_t)(size_t)&fvertexData[0];
+		return (uintptr_t)(size_t)&fvertexData[0];
 	}
 
     uint32_t IfcGeometry::GetVertexDataSize()
@@ -236,9 +236,9 @@ namespace webifc::geometry {
 		return (uint32_t)fvertexData.size();
 	}
 
-	uint32_t IfcGeometry::GetIndexData()
+	uintptr_t IfcGeometry::GetIndexData()
 	{
-		return (uint32_t)(size_t)&indexData[0];
+		return (uintptr_t)(size_t)&indexData[0];
 	}
 
 	uint32_t IfcGeometry::GetIndexDataSize()

--- a/src/cpp/web-ifc/geometry/representation/IfcGeometry.h
+++ b/src/cpp/web-ifc/geometry/representation/IfcGeometry.h
@@ -60,9 +60,9 @@ namespace webifc::geometry {
 		void AddPart(Geometry geom);
 		void AddGeometry(Geometry geom, glm::dmat4 trans = glm::dmat4(1), double scx = 1, double scy = 1, double scz = 1, glm::dvec3 origin = glm::dvec3(0, 0, 0));
 		void MergeGeometry(Geometry geom);
-		uint32_t GetVertexData();
+		uintptr_t GetVertexData();
 		uint32_t GetVertexDataSize();
-		uint32_t GetIndexData();
+		uintptr_t GetIndexData();
 		uint32_t GetIndexDataSize();
 		SweptDiskSolid GetSweptDiskSolid();
 		glm::dmat4 Normalize();

--- a/src/cpp/web-ifc/parsing/IfcFileStream.cpp
+++ b/src/cpp/web-ifc/parsing/IfcFileStream.cpp
@@ -14,7 +14,10 @@
 
    IfcTokenStream::IfcFileStream::~IfcFileStream() 
    {
-    delete _buffer;
+    if (_buffer != nullptr) {
+      delete[] _buffer;
+      _buffer = nullptr;
+    }
    }
    
    void IfcTokenStream::IfcFileStream::load()

--- a/src/cpp/web-ifc/parsing/IfcTokenChunk.cpp
+++ b/src/cpp/web-ifc/parsing/IfcTokenChunk.cpp
@@ -19,7 +19,7 @@ namespace webifc::parsing
   bool IfcTokenStream::IfcTokenChunk::Clear(bool force)
   {
     if (_fileStream==nullptr && !force) return false; 
-    if (_chunkData!=nullptr) delete[] _chunkData;
+    if (_chunkData!=nullptr) { delete[] _chunkData; _chunkData = nullptr; }
     _loaded=false;
     return true;
   }


### PR DESCRIPTION
Fixed unsafe deletion of heap-allocated arrays. The destructor in IfcFileStream previously used delete _buffer; which is incorrect for arrays and can lead to undefined behaviour. It now checks for nullptr.

The functions `GetVertexData()` and `GetIndexData()` previously returned uint32_t but returned pointer-sized integer values (addresses of vector buffers). These were changed to `uintptr_t` to safely represent pointer-sized integers on all platforms (including 64-bit/WASM pointers)