### PR TITLE
Add CMake install target for native C++ library usage

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -69,14 +69,14 @@ FetchContent_GetProperties(stduuid)
 Message("Downloads Finished")
 
 function(PARAM_SETTER THE_EXECUTABLE)
-	target_include_directories(${THE_EXECUTABLE} PUBLIC ${tinynurbs_SOURCE_DIR}/include)
-	target_include_directories(${THE_EXECUTABLE} PUBLIC ${fastfloat_SOURCE_DIR}/include)
-	target_include_directories(${THE_EXECUTABLE} PUBLIC ${cdt_SOURCE_DIR}/CDT/include)
-	target_include_directories(${THE_EXECUTABLE} PUBLIC ${glm_SOURCE_DIR}/)
-	target_include_directories(${THE_EXECUTABLE} PUBLIC ${glm_SOURCE_DIR}/glm)
-	target_include_directories(${THE_EXECUTABLE} PUBLIC ${earcut_SOURCE_DIR}/include)
-	target_include_directories(${THE_EXECUTABLE} PUBLIC ${spdlog_SOURCE_DIR}/include)
-	target_include_directories(${THE_EXECUTABLE} PUBLIC ${stduuid_SOURCE_DIR}/include)
+	target_include_directories(${THE_EXECUTABLE} PUBLIC $<BUILD_INTERFACE:${tinynurbs_SOURCE_DIR}/include>)
+	target_include_directories(${THE_EXECUTABLE} PUBLIC $<BUILD_INTERFACE:${fastfloat_SOURCE_DIR}/include>)
+	target_include_directories(${THE_EXECUTABLE} PUBLIC $<BUILD_INTERFACE:${cdt_SOURCE_DIR}/CDT/include>)
+	target_include_directories(${THE_EXECUTABLE} PUBLIC $<BUILD_INTERFACE:${glm_SOURCE_DIR}/>)
+	target_include_directories(${THE_EXECUTABLE} PUBLIC $<BUILD_INTERFACE:${glm_SOURCE_DIR}/glm>)
+	target_include_directories(${THE_EXECUTABLE} PUBLIC $<BUILD_INTERFACE:${earcut_SOURCE_DIR}/include>)
+	target_include_directories(${THE_EXECUTABLE} PUBLIC $<BUILD_INTERFACE:${spdlog_SOURCE_DIR}/include>)
+	target_include_directories(${THE_EXECUTABLE} PUBLIC $<BUILD_INTERFACE:${stduuid_SOURCE_DIR}/include>)
 
 	if(NOT MSVC)
 		target_compile_options(${THE_EXECUTABLE} PUBLIC "-Wall")
@@ -117,9 +117,20 @@ if(EMSCRIPTEN)
 endif()
 
 if(NOT EMSCRIPTEN)
+	include(GNUInstallDirs)
+	include(CMakePackageConfigHelpers)
+
 	# build web-ifc as a static library
 	add_library(web-ifc-library STATIC ${web-ifc-source})
 	param_setter(web-ifc-library)
+
+	# Add generator expressions for install support
+	target_include_directories(web-ifc-library PUBLIC
+		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/web-ifc>
+		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/web-ifc>
+	)
 
 	# build parameters for web-ifc-test
 	add_executable(web-ifc-test ${web-ifc-source} "./test/encoding_test.cpp" "./test/main.cpp" "./test/io_helpers.cpp")
@@ -139,4 +150,64 @@ if(NOT EMSCRIPTEN)
 		target_compile_options(web-ifc PUBLIC "-DCSG_DEBUG_OUTPUT")
 		target_compile_options(web-ifc PUBLIC "-DDEBUG_DUMP_SVG")
 	endif()
+
+	# Installation rules
+	# Install the static library
+	install(TARGETS web-ifc-library
+		EXPORT web-ifc-targets
+		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+		LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	)
+
+	# Install web-ifc headers
+	install(DIRECTORY web-ifc/
+		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/web-ifc
+		FILES_MATCHING PATTERN "*.h"
+	)
+
+	# Install version.h
+	install(FILES version.h
+		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/web-ifc
+	)
+
+	# Install bundled dependency headers (all header-only)
+	install(DIRECTORY ${fastfloat_SOURCE_DIR}/include/
+		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+	)
+	install(DIRECTORY ${tinynurbs_SOURCE_DIR}/include/
+		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+	)
+	install(DIRECTORY ${glm_SOURCE_DIR}/glm
+		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+	)
+	install(DIRECTORY ${earcut_SOURCE_DIR}/include/
+		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+	)
+	install(DIRECTORY ${cdt_SOURCE_DIR}/CDT/include/
+		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+	)
+	install(DIRECTORY ${spdlog_SOURCE_DIR}/include/
+		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+	)
+	install(DIRECTORY ${stduuid_SOURCE_DIR}/include/
+		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+	)
+
+	# Export targets with namespace
+	install(EXPORT web-ifc-targets
+		FILE web-ifc-targets.cmake
+		NAMESPACE web-ifc::
+		DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/web-ifc
+	)
+
+	# Generate and install CMake config file
+	configure_package_config_file(
+		${CMAKE_CURRENT_SOURCE_DIR}/cmake/web-ifc-config.cmake.in
+		${CMAKE_CURRENT_BINARY_DIR}/web-ifc-config.cmake
+		INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/web-ifc
+	)
+
+	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/web-ifc-config.cmake
+		DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/web-ifc
+	)
 endif()

--- a/src/cpp/cmake/web-ifc-config.cmake.in
+++ b/src/cpp/cmake/web-ifc-config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/web-ifc-targets.cmake")
+
+check_required_components(web-ifc)


### PR DESCRIPTION
Add CMake install support so web-ifc can be used as a native C++ dependency via find_package(web-ifc).