### PR TITLE
Fix ISO 10303-21 `\S\` page encoding when followed by an apostrophe character

### DIFF
--- a/src/cpp/web-ifc/parsing/IfcTokenChunk.cpp
+++ b/src/cpp/web-ifc/parsing/IfcTokenChunk.cpp
@@ -68,6 +68,17 @@ namespace webifc::parsing
             // if its a quote, maybe its the end of the string
             if (_fileStream->Get() == '\'')
             {
+              // ISO 10303-21: \S\c encodes a single character c with high bit set.
+              // If c happens to be an apostrophe, it is NOT a string terminator.
+              size_t sz = temp.size();
+              if (sz >= 4 &&
+                  temp[sz - 4] == '\\' &&
+                  (temp[sz - 3] == 'S' || temp[sz - 3] == 's') &&
+                  temp[sz - 2] == '\\')
+              {
+                _fileStream->Forward();
+                continue;
+              }
               // if there's another quote behind it, its not
               _fileStream->Forward();
               if (_fileStream->Get() == '\'')


### PR DESCRIPTION
This fixes loading of https://github.com/IfcOpenShell/step-file-parser/blob/master/fixtures/pass_page_encoding.ifc.

The string `'abc\S\'def'` caused the tokenizer to prematurely terminate the string at the `'` after `\S\`, corrupting the token stream and leading to an access violation during geometry processing. Fixed by detecting the `\S\` escape pattern before treating an apostrophe as a string terminator.