### PR TITLE
Require dimension 3 for IFCARBITRARYPROFILEDEFWITHVOIDS

### DIFF
--- a/src/cpp/web-ifc/geometry/IfcGeometryLoader.cpp
+++ b/src/cpp/web-ifc/geometry/IfcGeometryLoader.cpp
@@ -3150,7 +3150,8 @@ namespace webifc::geometry
       _loader.MoveToArgumentOffset(expressID, 0);
       profile.type = _loader.GetStringArgument();
       _loader.MoveToArgumentOffset(expressID, 2);
-      profile.curve = GetCurve(_loader.GetRefArgument(), 2);
+      // Same as IFCARBITRARYCLOSEDPROFILEDEF: 3D curves require dimension 3
+      profile.curve = GetCurve(_loader.GetRefArgument(), 3);
       profile.isConvex = IsCurveConvex(profile.curve);
 
       _loader.MoveToArgumentOffset(expressID, 3);
@@ -3158,7 +3159,7 @@ namespace webifc::geometry
 
       for (auto &hole : holes)
       {
-        IfcCurve holeCurve = GetCurve(_loader.GetRefArgument(hole), 2);
+        IfcCurve holeCurve = GetCurve(_loader.GetRefArgument(hole), 3);
         profile.holes.push_back(holeCurve);
       }
 

--- a/src/cpp/web-ifc/geometry/IfcGeometryLoader.cpp
+++ b/src/cpp/web-ifc/geometry/IfcGeometryLoader.cpp
@@ -3150,7 +3150,7 @@ namespace webifc::geometry
       _loader.MoveToArgumentOffset(expressID, 0);
       profile.type = _loader.GetStringArgument();
       _loader.MoveToArgumentOffset(expressID, 2);
-      // Same as IFCARBITRARYCLOSEDPROFILEDEF: 3D curves require dimension 3
+      // ISSUE 1973 same as IFCARBITRARYCLOSEDPROFILEDEF: 3D curves require dimension 3
       profile.curve = GetCurve(_loader.GetRefArgument(), 3);
       profile.isConvex = IsCurveConvex(profile.curve);
 


### PR DESCRIPTION
Fix issue #1973

`IFCARBITRARYPROFILEDEFWITHVOIDS` was calling `GetCurve(..., 2)` (dimensions=2) for both the outer boundary and void curves.
When the profile boundary is defined by 3D curves (IFCCOMPOSITECURVE -> IFCTRIMMEDCURVE -> IFCLINE with 3D points),
the 2D code path calls `GetCartesianPoint2D` which reads only the `x` and `y` coordinates.
This produces wrong geometry whenever the `z` component of the line origin is non-zero.
`IFCARBITRARYCLOSEDPROFILEDEF` already had the same fix applied (comment referencing issues #765 and #1604), but `IFCARBITRARYPROFILEDEFWITHVOIDS` was missed.