### PR TITLE
fix(schema): wrap IfcArcIndex/IfcLineIndex indices as IfcPositiveInteger

### DIFF
--- a/src/schema-generator/gen_functional_types_helpers.ts
+++ b/src/schema-generator/gen_functional_types_helpers.ts
@@ -7,7 +7,9 @@ export function generateInitialiser(type: Type, initialisersDone: Set<string>,bu
     if (type.isList)
     {
         if (initialisersDone.has(type.name)) return;
-        buffer.push(`${crc32(type.name.toUpperCase(),crcTable)}:(v:any) => new ${schemaName}.${type.name}(v.map( (x:any) => x.value)),`);
+        const elementIsIfcType = types.some((t: Type) => t.name === type.typeName);
+        const valueExpr = elementIsIfcType ? `new ${schemaName}.${type.typeName}(x.value)` : `x.value`;
+        buffer.push(`${crc32(type.name.toUpperCase(),crcTable)}:(v:any) => new ${schemaName}.${type.name}(v.map( (x:any) => ${valueExpr})),`);
         initialisersDone.add(type.name);
         return
     }
@@ -69,7 +71,11 @@ export function generatePropAssignment(p: Prop, i:number, types:Type[],schemaNam
 
     }
     else if (isType) {
-        if (type?.isList) content='new '+schemaName+'.'+p.type+'(v['+i+'].map( (x:any) => x.value))';
+        if (type?.isList) {
+        const elemIsIfcType = type.typeName ? types.some((t: Type) => t.name === type.typeName) : false;
+        const valExpr = elemIsIfcType ? `new ${schemaName}.${type.typeName}(x.value)` : `x.value`;
+        content = `new ${schemaName}.${p.type}(v[${i}].map( (x:any) => ${valExpr}))`;
+    }
         else content = 'new '+schemaName+'.'+p.type+'(' + valueCheckPrefix + 'v['+i+'].value)';
     }
     else if (p.primitive && p.type === "number") content = 'new NumberHandle('+valueCheckPrefix+'v['+i+'].value, '+p.typeNum+')';

--- a/tests/test_issue_1881.cjs
+++ b/tests/test_issue_1881.cjs
@@ -1,0 +1,41 @@
+const WebIFC = require("../dist/web-ifc-api-node.js");
+const path = require("path");
+
+// IFC mínim en memòria — sense fitxer
+const IFC = `ISO-10303-21;
+HEADER;FILE_DESCRIPTION(('test'),'2;1');FILE_NAME('','',(''),(''),'','','');FILE_SCHEMA(('IFC4'));ENDSEC;
+DATA;
+#1=IFCCARTESIANPOINTLIST2D(((0.,0.),(1.,1.),(2.,0.)));
+#2=IFCINDEXEDPOLYCURVE(#1,(IFCARCINDEX((1,2,3))),.F.);
+ENDSEC;END-ISO-10303-21;`;
+
+async function test() {
+    const api = new WebIFC.IfcAPI();
+    await api.Init();
+
+    const modelID = api.OpenModel(Buffer.from(IFC));
+    const ids = api.GetLineIDsWithType(modelID, WebIFC.IFCINDEXEDPOLYCURVE);
+    console.log("IfcIndexedPolyCurve trobats:", ids.size());
+
+    // GetLine(false) = FromRawLineData sense FlattenLine (que confon IfcArcIndex amb Handle)
+    const entity = api.GetLine(modelID, ids.get(0), false);
+
+    const segment = entity.Segments[0];  // IfcArcIndex
+    const index   = segment.value[0];    // ha de ser IfcPositiveInteger, no number
+
+    console.log("\n--- Verificació Issue #1881 ---");
+    console.log("Segment classe:  ", segment?.constructor?.name);     // IfcArcIndex
+    console.log("Índex classe:    ", index?.constructor?.name);       // BEFORE: Number  | AFTER: IfcPositiveInteger
+    console.log("Índex .type:     ", index?.type);                    // BEFORE: undefined| AFTER: 10
+    console.log("Índex .name:     ", index?.name);                    // BEFORE: undefined| AFTER: IFCPOSITIVEINTEGER
+    console.log("Índex .value:    ", index?.value ?? index);          // 1 en ambdós casos
+
+    const ok = index?.constructor?.name === "IfcPositiveInteger" && index?.type === 10;
+    console.log(ok ? "\n✓ FIX VERIFICAT: els índexs son IfcPositiveInteger"
+                   : "\n✗ BUG PRESENT: els índexs son numbers bruts");
+
+    api.CloseModel(modelID);
+    api.Dispose();
+}
+
+test().catch(console.error);


### PR DESCRIPTION
In generateInitialiser and generatePropAssignment, list types whose element type is itself an IFC type (e.g. IfcPositiveInteger) were deserialised using raw x.value (a plain number) instead of wrapping each element in the correct typed constructor.

This caused IfcArcIndex and IfcLineIndex to expose Array<number> instead of Array<IfcPositiveInteger> through the TypeScript API, breaking instanceof checks and the .type discriminator field.

Fix: detect when a list element type exists in the IFC types registry and emit new SchemaName.TypeName(x.value) instead of x.value.

Fixes #1881