### PR TITLE
Fix cap vertex normals of oblique IfcExtrudedAreaSolid

### DIFF
--- a/src/cpp/web-ifc/geometry/operations/bim-geometry/utils.h
+++ b/src/cpp/web-ifc/geometry/operations/bim-geometry/utils.h
@@ -645,7 +645,19 @@ namespace bimGeometry
 			int polygonCount = profile.size(); // Main profile + holes
 			std::vector<std::vector<Point>> polygon(polygonCount);
 
-			glm::dvec3 normal = dir;
+			glm::dvec3 capNormal(0);
+			for (size_t i = 0, n = profile[0].size(); i < n; i++)
+			{
+				capNormal += glm::cross(profile[0][i], profile[0][(i + 1) % n]);
+			}
+			double capNormalLength = glm::length(capNormal);
+			capNormal = capNormalLength > 0 ? capNormal / capNormalLength : glm::normalize(dir);
+			if (glm::dot(capNormal, dir) < 0)
+			{
+				capNormal = -capNormal;
+			}
+
+			glm::dvec3 normal = capNormal;
 
 			for (size_t i = 0; i < profile[0].size(); i++)
 			{
@@ -707,7 +719,15 @@ namespace bimGeometry
 
 			offset += geom.numPoints;
 
-			normal = -dir;
+			normal = -capNormal;
+			if (cuttingPlaneNormal != glm::dvec3(0))
+			{
+				normal = glm::normalize(cuttingPlaneNormal);
+				if (glm::dot(normal, dir) > 0)
+				{
+					normal = -normal;
+				}
+			}
 
 			for (size_t i = 0; i < profile[0].size(); i++)
 			{

--- a/tests/functional/ExtrusionCapNormals.spec.ts
+++ b/tests/functional/ExtrusionCapNormals.spec.ts
@@ -1,0 +1,116 @@
+import * as WebIFC from '../../dist/web-ifc-api-node.js';
+import {IFCBUILDINGELEMENTPROXY} from '../../dist/web-ifc-api-node.js';
+
+import type {IfcAPI} from '../../dist/web-ifc-api-node.js';
+
+const OBLIQUE_EXTRUSION_IFC = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCCARTESIANPOINT((0.,0.,0.));
+#2=IFCDIRECTION((0.,0.,1.));
+#3=IFCDIRECTION((1.,0.,0.));
+#4=IFCAXIS2PLACEMENT3D(#1,#2,#3);
+#5=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0000000000000001E-05,#4,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#7=IFCSIUNIT(*,.AREAUNIT.,$,.SQUARE_METRE.);
+#8=IFCSIUNIT(*,.VOLUMEUNIT.,$,.CUBIC_METRE.);
+#9=IFCUNITASSIGNMENT((#6,#7,#8));
+#10=IFCPROJECT('2f_i2TP$150hNbqDbwEUL1',$,'Oblique extrusion repro',$,$,$,$,(#5),#9);
+#11=IFCAXIS2PLACEMENT3D(#1,$,$);
+#12=IFCLOCALPLACEMENT($,#11);
+#13=IFCSITE('0z6rD9EWn33QJVUZExLX2Y',$,'Site',$,$,#12,$,$,.ELEMENT.,$,$,$,$,$);
+#14=IFCRELAGGREGATES('0TkvLXYq52jRxohG2h9SSr',$,$,$,#10,(#13));
+#15=IFCRECTANGLEPROFILEDEF(.AREA.,$,$,2.,1.);
+#16=IFCDIRECTION((0.,0.,1.));
+#17=IFCEXTRUDEDAREASOLID(#15,$,#16,3.);
+#18=IFCSHAPEREPRESENTATION(#5,'Body','SweptSolid',(#17));
+#19=IFCPRODUCTDEFINITIONSHAPE($,$,(#18));
+#20=IFCCARTESIANPOINT((0.,0.,0.));
+#21=IFCAXIS2PLACEMENT3D(#20,$,$);
+#22=IFCLOCALPLACEMENT(#12,#21);
+#23=IFCBUILDINGELEMENTPROXY('2$wN9$6EH8VwEE17izw0qF',$,'perpendicular box',$,$,#22,#19,$,$);
+#24=IFCRECTANGLEPROFILEDEF(.AREA.,$,$,2.,1.);
+#25=IFCDIRECTION((0.,0.70710678118654757,0.70710678118654757));
+#26=IFCEXTRUDEDAREASOLID(#24,$,#25,3.);
+#27=IFCSHAPEREPRESENTATION(#5,'Body','SweptSolid',(#26));
+#28=IFCPRODUCTDEFINITIONSHAPE($,$,(#27));
+#29=IFCCARTESIANPOINT((5.,0.,0.));
+#30=IFCAXIS2PLACEMENT3D(#29,$,$);
+#31=IFCLOCALPLACEMENT(#12,#30);
+#32=IFCBUILDINGELEMENTPROXY('1boC6KILrCrPTXUvdBNeDo',$,'oblique box',$,$,#31,#28,$,$);
+#33=IFCRELCONTAINEDINSPATIALSTRUCTURE('30Mj6b91v3cwc4FkOgiRIL',$,$,$,(#23,#32),#13);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+let ifcApi: IfcAPI;
+let modelID: number;
+
+function minStoredVsGeometricNormalDot(expressID: number): number {
+    const flatMesh = ifcApi.GetFlatMesh(modelID, expressID);
+    let minDot = 2;
+    for (let g = 0; g < flatMesh.geometries.size(); g++) {
+        const placedGeometry = flatMesh.geometries.get(g);
+        const geometry = ifcApi.GetGeometry(modelID, placedGeometry.geometryExpressID);
+        const indices = ifcApi.GetIndexArray(geometry.GetIndexData(), geometry.GetIndexDataSize());
+        const vertices = ifcApi.GetVertexArray(geometry.GetVertexData(), geometry.GetVertexDataSize());
+        for (let t = 0; t < indices.length; t += 3) {
+            const position = (k: number) => [vertices[6 * indices[t + k]], vertices[6 * indices[t + k] + 1], vertices[6 * indices[t + k] + 2]];
+            const storedNormal = (k: number) => [vertices[6 * indices[t + k] + 3], vertices[6 * indices[t + k] + 4], vertices[6 * indices[t + k] + 5]];
+            const [a, b, c] = [position(0), position(1), position(2)];
+            const ab = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+            const ac = [c[0] - a[0], c[1] - a[1], c[2] - a[2]];
+            const cross = [ab[1] * ac[2] - ab[2] * ac[1], ab[2] * ac[0] - ab[0] * ac[2], ab[0] * ac[1] - ab[1] * ac[0]];
+            const crossLength = Math.hypot(cross[0], cross[1], cross[2]);
+            if (crossLength < 1e-12) continue;
+            const geometricNormal = cross.map(x => x / crossLength);
+            for (const k of [0, 1, 2]) {
+                const stored = storedNormal(k);
+                const dot = Math.abs(geometricNormal[0] * stored[0] + geometricNormal[1] * stored[1] + geometricNormal[2] * stored[2]);
+                minDot = Math.min(minDot, dot);
+            }
+        }
+    }
+    return minDot;
+}
+
+beforeAll(async () => {
+    ifcApi = new WebIFC.IfcAPI();
+    await ifcApi.Init();
+    ifcApi.SetLogLevel(WebIFC.LogLevel.LOG_LEVEL_OFF);
+    modelID = ifcApi.OpenModel(new TextEncoder().encode(OBLIQUE_EXTRUSION_IFC));
+});
+
+afterAll(() => {
+    ifcApi.CloseModel(modelID);
+});
+
+describe('IfcExtrudedAreaSolid cap normals', () => {
+    test('stored vertex normals match geometric normals for a perpendicular extrusion', () => {
+        const ids = ifcApi.GetLineIDsWithType(modelID, IFCBUILDINGELEMENTPROXY);
+        let checked = 0;
+        for (let i = 0; i < ids.size(); i++) {
+            const id = ids.get(i);
+            if (!ifcApi.GetLine(modelID, id).Name.value.includes('perpendicular')) continue;
+            expect(minStoredVsGeometricNormalDot(id)).toBeGreaterThan(0.999);
+            checked++;
+        }
+        expect(checked).toBe(1);
+    });
+
+    test('stored vertex normals match geometric normals for an oblique extrusion', () => {
+        const ids = ifcApi.GetLineIDsWithType(modelID, IFCBUILDINGELEMENTPROXY);
+        let checked = 0;
+        for (let i = 0; i < ids.size(); i++) {
+            const id = ids.get(i);
+            if (!ifcApi.GetLine(modelID, id).Name.value.includes('oblique')) continue;
+            expect(minStoredVsGeometricNormalDot(id)).toBeGreaterThan(0.999);
+            checked++;
+        }
+        expect(checked).toBe(1);
+    });
+});


### PR DESCRIPTION
I noticed the roof of the IfcOpenHouse model shading not correct at the vertical eave faces. The roof there is an `IfcExtrudedAreaSolid` with an `ExtrudedDirection` not perpendicular to the profile plane. I see that it happens both with the original file by Thomas Krijnen, already bundled in this repo in `tests/ifcfiles/public/IfcOpenHouse_IFC4.ifc`, and with [another version I did with the ifcopenshell API](https://github.com/cvillagrasa/IfcOpenHouse/blob/master/ifc/IfcOpenHouse.ifc).

<img width="1528" height="1003" alt="IfcOpenHouse_roof_bug" src="https://github.com/user-attachments/assets/68ac7be4-04b0-4eee-88e6-82f4696d5a3b" />

It seems that the cause is that the extrusion tessellator stores the extrusion direction as the vertex normal of both cap faces. The caps of an extrusion lie in planes parallel to the profile plane regardless of the direction, so this is only correct when the extrusion is perpendicular, not for a 45° oblique roof.

The following lines reproduce the issue:
```
#26=IFCDIRECTION((0.,0.70710678118654757,0.70710678118654757));
#25=IFCRECTANGLEPROFILEDEF(.AREA.,$,$,2.,1.);
#27=IFCEXTRUDEDAREASOLID(#25,$,#26,3.);
```

Bisecting the npm releases: up to 0.0.51 render correctly, 0.0.52 onwards do not. The tessellator has always written `dir` as the cap normal, but until 0.0.52 every mesh was round-tripped through `fuzzybools::Geometry::Normalize`, which rebuilt vertex normals from triangle positions and silently corrected the caps. Commit 97714b48 removed that round-trip while fixing #664 and #597, and the raw tessellator cap normals became visible.

In this PR, in `bimGeometry::Extrude` (`src/cpp/web-ifc/geometry/operations/bim-geometry/utils.h`):

* The stored cap normal is the profile-plane normal, computed with Newell's method over the outer profile contour and oriented outward (top cap along the extrusion direction, bottom cap against it). For perpendicular extrusions this is identical to the previous behaviour.
* When the bottom cap is projected onto a cutting plane (`cuttingPlaneNormal` provided), that plane's normal is used instead, also oriented against the extrusion direction.

Side faces are unaffected, since they already compute geometric normals via `AddFace(a, b, c)`. Vertex positions, indices and transformations are untouched.

`tests/functional/ExtrusionCapNormals.spec.ts` loads the fixture (one perpendicular box, one oblique box) and asserts that every stored vertex normal matches the geometric triangle normal. The oblique case fails before this change (`minDot = 0.7071`) and passes after (`minDot = 1.0`). The perpendicular case passes before and after. IfcOpenHouse roofs also come out exact (`dot = 1.0` on all triangles) with the fix.
