### PR TITLE
fix: pass mainScriptUrlOrBlob so the pthread worker resolves its script URL under ESM

### DIFF
--- a/src/ts/web-ifc-api.ts
+++ b/src/ts/web-ifc-api.ts
@@ -413,6 +413,18 @@ export class IfcAPI {
         const modulePromise = WebIFCWasm({
           noInitialRun: true,
           locateFile: customLocateFileHandler || locateFileHandler,
+          // The generated pthread bootstrap falls back to
+          // `document.currentScript?.src` to find its own script URL when
+          // spawning its worker. That is always `undefined` when this
+          // module is loaded as an ES module (which is how `web-ifc` is
+          // distributed and how virtually every modern bundler loads it),
+          // causing `new Worker(undefined)` and a silent hang. Passing
+          // `mainScriptUrlOrBlob` explicitly (which the generated bootstrap
+          // already prefers over `document.currentScript` when present)
+          // avoids that entirely. `import.meta.url` is correctly populated
+          // for ES modules, unlike `document.currentScript`.
+          // @ts-ignore
+          ...(shouldRetrySingleThread ? { mainScriptUrlOrBlob: import.meta.url } : {}),
         });
         if (shouldRetrySingleThread) {
           this.wasmModule = await Promise.race([


### PR DESCRIPTION
### Summary

Partial fix for #2068.

When `web-ifc` is loaded as an ES module, `document.currentScript` is always `null` per spec, so the generated pthread bootstrap ends up calling `new Worker(undefined)` and multi-threaded init fails. Since #1946 that no longer hangs forever, but it does burn the full `MT_INIT_TIMEOUT_MS` and then falls back to single-threaded — so MT is effectively unavailable to ESM consumers (i.e. anyone using a modern bundler).

This passes `mainScriptUrlOrBlob: import.meta.url` into the module factory. The generated bootstrap already prefers `mainScriptUrlOrBlob` over `document.currentScript`, and `import.meta.url` is correctly populated for ES modules.

### Notes

- Applied only on the multi-threaded path (`shouldRetrySingleThread`, which is set exactly when the MT module is selected) — `mainScriptUrlOrBlob` is only consulted when a pthread worker is spawned, so there is no reason to pass it for the single-threaded module. Happy to make it unconditional if you prefer.
- The `// @ts-ignore` is needed because `tsconfig.json` uses `"module": "node16"` while the root `package.json` has no `"type": "module"`, so `tsc` (used here only for `--emitDeclarationOnly`) rejects `import.meta`. esbuild, which produces all three actual bundles, handles it fine.

### This does not fully restore multi-threading

A second, independent defect remains: the generated bootstrap creates the worker via

```js
new Worker(pthreadMainJs, { name: "em-pthread" })   // no { type: "module" }
```

so it still cannot parse ESM content. That line is Emscripten-generated and isn't reachable from this source tree — it needs a change on the build/toolchain side. Details in #2068.

### Test plan

- `npm run build-ts-api` passes.
- Verified in a Vite app with COOP/COEP enabled (`crossOriginIsolated === true`) that the worker URL is no longer `undefined` — the failure moves from the `/undefined` 404 on to the second defect above.
