### PR TITLE
Fix winding reversal of IFCEDGELOOP brep faces (regression 0.74 -> 0.75)

### DIFF
--- a/src/cpp/web-ifc/geometry/IfcGeometryLoader.cpp
+++ b/src/cpp/web-ifc/geometry/IfcGeometryLoader.cpp
@@ -1353,7 +1353,12 @@ namespace webifc::geometry
             // Check connection and reverse if needed
             auto& ec = edgeCurve.points; // referència per brevetat
             if (!ec.empty()) {
-                if (nearEqual(curve.points.back(), ec.back())) {
+                if (nearEqual(curve.points.back(), ec.front())) {
+                    // Normal continuation: the edge starts where the loop currently ends.
+                    // This also covers the closing edge of a correctly-ordered loop, which
+                    // ends at the loop start point and must not trigger a reversal.
+                }
+                else if (nearEqual(curve.points.back(), ec.back())) {
                     std::reverse(ec.begin(), ec.end());
                 }
                 else if (nearEqual(curve.points.front(), ec.front())) {


### PR DESCRIPTION
Fixes https://github.com/ThatOpen/engine_web-ifc/issues/1922

## Root cause

The "Issue #1144" edge-connection heuristic added to `GetLoop` in `IfcGeometryLoader.cpp` reverses edge-loop segments that do not connect end-to-start. Its third branch (`nearEqual(curve.front(), ec.back())`) also fires on the closing edge of a correctly-ordered loop, because every closed edge loop ends at its start point. This reversed the winding of every IFCEDGELOOP-based brep face.

## Consequences (verified on the [issue1922.ifc](https://github.com/user-attachments/files/26306063/ifc.txt) repro)

- Brep-based elements (window, opening) rendered inside-out (signed volume -0.1534 / -2.644 vs +0.1534 / +2.644 in 0.74).
- The reversed void brep also degraded the boolean-carved wall: 126 verts/42 faces with duplicate degenerate triangles vs 96 verts/32 faces in 0.74.

## Fix

Prioritize the normal-continuation case (`nearEqual(curve.back(), ec.front())`) before the reversal branches, so correctly-connected edges - including the closing edge - are never reversed. Genuinely malformed/backwards loops still hit the original reversal branches, preserving the #1144 behavior.

## Verification

With the fix, wall # 1, window # 42 and opening # 2509 of the repro produce identical world geometry to tag 0.74 (all 14 window breps byte-identical, signed volumes match exactly).
